### PR TITLE
GTNPORTAL-2675:The InitTasked called during PortalContainerConfigOwner....

### DIFF
--- a/exo.kernel.container/src/main/java/org/exoplatform/container/PortalContainer.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/PortalContainer.java
@@ -21,6 +21,7 @@ package org.exoplatform.container;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.container.RootContainer.PortalContainerInitTask;
+import org.exoplatform.container.RootContainer.PortalContainerPostInitTask;
 import org.exoplatform.container.RootContainer.PortalContainerPreInitTask;
 import org.exoplatform.container.definition.PortalContainerConfig;
 import org.exoplatform.container.jmx.MX4JComponentAdapterFactory;
@@ -753,6 +754,17 @@ public class PortalContainer extends ExoContainer implements SessionManagerConta
     * This class is used to unregister a portal container
     */
    public static class UnregisterTask extends PortalContainerPreInitTask
+   {
+      public void execute(ServletContext context, PortalContainer portalContainer)
+      {
+         portalContainer.unregisterContext(context);
+      }
+   }
+   
+   /**
+    * This class is used to unregister a portal container
+    */
+   public static class PostUnregisterTask extends PortalContainerPostInitTask
    {
       public void execute(ServletContext context, PortalContainer portalContainer)
       {

--- a/exo.kernel.container/src/main/java/org/exoplatform/container/web/PortalContainerConfigOwner.java
+++ b/exo.kernel.container/src/main/java/org/exoplatform/container/web/PortalContainerConfigOwner.java
@@ -53,6 +53,6 @@ public class PortalContainerConfigOwner implements ServletContextListener
 
    public void contextDestroyed(ServletContextEvent event)
    {
-      PortalContainer.addInitTask(event.getServletContext(), new PortalContainer.UnregisterTask());
+      PortalContainer.addInitTask(event.getServletContext(), new PortalContainer.PostUnregisterTask());
    }
 }


### PR DESCRIPTION
...contextDestroyed was a pre init task, but since the portal container is already started during a contextDestroy it needs to be a post init task. This removes a error message which occurs from extensions during portal shutdown.
