### PR TITLE
KER-245 : InvalidMagicMimeEntryException when starting PLF 3.5.7 on RHEL...

### DIFF
--- a/exo.kernel.commons.test/pom.xml
+++ b/exo.kernel.commons.test/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.commons.test</artifactId>

--- a/exo.kernel.commons.test/pom.xml
+++ b/exo.kernel.commons.test/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.commons.test</artifactId>

--- a/exo.kernel.commons/pom.xml
+++ b/exo.kernel.commons/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.commons</artifactId>

--- a/exo.kernel.commons/pom.xml
+++ b/exo.kernel.commons/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.commons</artifactId>

--- a/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/MimeTypeResolver.java
+++ b/exo.kernel.commons/src/main/java/org/exoplatform/commons/utils/MimeTypeResolver.java
@@ -38,12 +38,27 @@ public class MimeTypeResolver
 {
    protected static final Log LOG = ExoLogger.getLogger("exo.kernel.commons.MimeTypeResolver");
 
+   /**
+    *  Name of mime cache file property parameter.
+    */
+   private static final String MIME_CACHE = "exo.mime.cache";
+
+
    static {
       SecurityHelper.doPrivilegedAction(new PrivilegedAction<Void>()
       {
          public Void run()
          {
-            MimeUtil.registerMimeDetector("eu.medsea.mimeutil.detector.MagicMimeMimeDetector");
+            String mimeCacheFile = PropertyManager.getProperty(MIME_CACHE);
+            if (mimeCacheFile != null && !mimeCacheFile.isEmpty())
+            {
+               new eu.medsea.mimeutil.detector.OpendesktopMimeDetector(mimeCacheFile);
+               MimeUtil.registerMimeDetector("eu.medsea.mimeutil.detector.OpendesktopMimeDetector");
+            }
+            else
+            {
+               MimeUtil.registerMimeDetector("eu.medsea.mimeutil.detector.MagicMimeMimeDetector");
+            }
             return null;
          }
       });

--- a/exo.kernel.component.cache/pom.xml
+++ b/exo.kernel.component.cache/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.component.cache</artifactId>

--- a/exo.kernel.component.cache/pom.xml
+++ b/exo.kernel.component.cache/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.component.cache</artifactId>

--- a/exo.kernel.component.command/pom.xml
+++ b/exo.kernel.component.command/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.component.command</artifactId>

--- a/exo.kernel.component.command/pom.xml
+++ b/exo.kernel.component.command/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.component.command</artifactId>

--- a/exo.kernel.component.common/pom.xml
+++ b/exo.kernel.component.common/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.component.common</artifactId>

--- a/exo.kernel.component.common/pom.xml
+++ b/exo.kernel.component.common/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.component.common</artifactId>

--- a/exo.kernel.component.ext.cache.impl.infinispan.v5/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.infinispan.v5/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.exoplatform.kernel</groupId>
 		<artifactId>kernel-parent</artifactId>
-		<version>2.4.4-GA-SNAPSHOT</version>
+		<version>2.4.4-GA</version>
 	</parent>
 	<artifactId>exo.kernel.component.ext.cache.impl.infinispan.v5</artifactId>
 	<name>eXo Kernel :: Cache Extension :: Infinispan Implementation</name>

--- a/exo.kernel.component.ext.cache.impl.infinispan.v5/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.infinispan.v5/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.exoplatform.kernel</groupId>
 		<artifactId>kernel-parent</artifactId>
-		<version>2.4.4-GA</version>
+		<version>2.4.5-GA-SNAPSHOT</version>
 	</parent>
 	<artifactId>exo.kernel.component.ext.cache.impl.infinispan.v5</artifactId>
 	<name>eXo Kernel :: Cache Extension :: Infinispan Implementation</name>

--- a/exo.kernel.component.ext.cache.impl.jboss.v3/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.jboss.v3/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
    <artifactId>exo.kernel.component.ext.cache.impl.jboss.v3</artifactId>
    <name>eXo Kernel :: Cache Extension :: JBoss Cache Implementation</name>

--- a/exo.kernel.component.ext.cache.impl.jboss.v3/pom.xml
+++ b/exo.kernel.component.ext.cache.impl.jboss.v3/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
    <artifactId>exo.kernel.component.ext.cache.impl.jboss.v3</artifactId>
    <name>eXo Kernel :: Cache Extension :: JBoss Cache Implementation</name>

--- a/exo.kernel.component.ext.rpc.impl.jgroups.v3/pom.xml
+++ b/exo.kernel.component.ext.rpc.impl.jgroups.v3/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
    <artifactId>exo.kernel.component.ext.rpc.impl.jgroups.v3</artifactId>
    <name>eXo Kernel :: RPC Service Extension :: JGroups 3 Implementation</name>

--- a/exo.kernel.component.ext.rpc.impl.jgroups.v3/pom.xml
+++ b/exo.kernel.component.ext.rpc.impl.jgroups.v3/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
    <artifactId>exo.kernel.component.ext.rpc.impl.jgroups.v3</artifactId>
    <name>eXo Kernel :: RPC Service Extension :: JGroups 3 Implementation</name>

--- a/exo.kernel.container/pom.xml
+++ b/exo.kernel.container/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
    <artifactId>exo.kernel.container</artifactId>
    <name>eXo Kernel :: Container</name>

--- a/exo.kernel.container/pom.xml
+++ b/exo.kernel.container/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
    <artifactId>exo.kernel.container</artifactId>
    <name>eXo Kernel :: Container</name>

--- a/exo.kernel.mc-integration/exo.kernel.mc-int-demo/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-int-demo/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.mc-int-demo</artifactId>

--- a/exo.kernel.mc-integration/exo.kernel.mc-int-demo/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-int-demo/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.mc-int-demo</artifactId>

--- a/exo.kernel.mc-integration/exo.kernel.mc-int-tests/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-int-tests/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.mc-int-tests</artifactId>

--- a/exo.kernel.mc-integration/exo.kernel.mc-int-tests/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-int-tests/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.mc-int-tests</artifactId>

--- a/exo.kernel.mc-integration/exo.kernel.mc-int/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-int/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.mc-int</artifactId>

--- a/exo.kernel.mc-integration/exo.kernel.mc-int/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-int/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.mc-int</artifactId>

--- a/exo.kernel.mc-integration/exo.kernel.mc-kernel-extras/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-kernel-extras/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>exo.kernel.mc-kernel-extras</artifactId>

--- a/exo.kernel.mc-integration/exo.kernel.mc-kernel-extras/pom.xml
+++ b/exo.kernel.mc-integration/exo.kernel.mc-kernel-extras/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>mc-integration-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>exo.kernel.mc-kernel-extras</artifactId>

--- a/exo.kernel.mc-integration/pom.xml
+++ b/exo.kernel.mc-integration/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA-SNAPSHOT</version>
+      <version>2.4.4-GA</version>
    </parent>
 
    <artifactId>mc-integration-parent</artifactId>

--- a/exo.kernel.mc-integration/pom.xml
+++ b/exo.kernel.mc-integration/pom.xml
@@ -27,7 +27,7 @@
    <parent>
       <groupId>org.exoplatform.kernel</groupId>
       <artifactId>kernel-parent</artifactId>
-      <version>2.4.4-GA</version>
+      <version>2.4.5-GA-SNAPSHOT</version>
    </parent>
 
    <artifactId>mc-integration-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
    <groupId>org.exoplatform.kernel</groupId>
    <artifactId>kernel-parent</artifactId>
-   <version>2.4.4-GA-SNAPSHOT</version>
+   <version>2.4.4-GA</version>
    <packaging>pom</packaging>
 
    <name>eXo Kernel</name>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
    <groupId>org.exoplatform.kernel</groupId>
    <artifactId>kernel-parent</artifactId>
-   <version>2.4.4-GA</version>
+   <version>2.4.5-GA-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <name>eXo Kernel</name>


### PR DESCRIPTION
KER-245 : InvalidMagicMimeEntryException when starting PLF 3.5.7 on RHEL 5.9