### PR TITLE
KER-276: Cluster configuration creates NPE in AbstractExoCache.select() at initialization

### DIFF
--- a/exo.kernel.component.ext.cache.impl.jboss.v3/src/main/java/org/exoplatform/services/cache/impl/jboss/AbstractExoCache.java
+++ b/exo.kernel.component.ext.cache.impl.jboss.v3/src/main/java/org/exoplatform/services/cache/impl/jboss/AbstractExoCache.java
@@ -176,7 +176,10 @@ public abstract class AbstractExoCache<K extends Serializable, V> implements Exo
    public List<V> getCachedObjects()
    {
       final LinkedList<V> list = new LinkedList<V>();
-      for (Node<K, V> node : cache.getNode(rootFqn).getChildren())
+      NodeSPI<K, V> rootNode = cache.getNode(rootFqn);
+      if (rootNode == null)
+         return list;
+      for (Node<K, V> node : rootNode.getChildren())
       {
          if (node == null)
          {
@@ -339,8 +342,11 @@ public abstract class AbstractExoCache<K extends Serializable, V> implements Exo
       if (selector == null)
       {
          throw new IllegalArgumentException("No null selector");
-      }      
-      for (Node<K, V> node : cache.getNode(rootFqn).getChildren())
+      }
+      NodeSPI<K, V> rootNode = cache.getNode(rootFqn);
+      if (rootNode == null)
+         return;
+      for (Node<K, V> node : rootNode.getChildren())
       {
          if (node == null)
          {

--- a/exo.kernel.component.ext.cache.impl.jboss.v3/src/test/java/org/exoplatform/services/cache/impl/jboss/TestAbstractExoCache.java
+++ b/exo.kernel.component.ext.cache.impl.jboss.v3/src/test/java/org/exoplatform/services/cache/impl/jboss/TestAbstractExoCache.java
@@ -181,6 +181,9 @@ public class TestAbstractExoCache extends TestCase
       assertTrue(values.contains("a"));
       assertTrue(values.contains("b"));
       assertTrue(values.contains("c"));
+      cache.clearCache();
+      values = cache.getCachedObjects();
+      assertEquals(0, values.size());
    }
 
    public void testRemoveCachedObjects() throws Exception
@@ -222,6 +225,10 @@ public class TestAbstractExoCache extends TestCase
       };
       cache.select(selector);
       assertEquals(3, count.intValue());
+      count.set(0);
+      cache.clearCache();
+      cache.select(selector);
+      assertEquals(0, count.intValue());
    }
 
    public void testGetHitsNMisses() throws Exception


### PR DESCRIPTION
https://jira.exoplatform.org/browse/KER-276
