### PR TITLE
KER-293: Cache misses should not be incremented only when the entry has expired

### DIFF
--- a/exo.kernel.component.cache/src/main/java/org/exoplatform/services/cache/concurrent/CacheState.java
+++ b/exo.kernel.component.cache/src/main/java/org/exoplatform/services/cache/concurrent/CacheState.java
@@ -85,6 +85,10 @@ class CacheState<K extends Serializable, V>
             config.onExpire(entry.name, o);
          }
       }
+      else
+      {
+         config.misses.incrementAndGet();
+      }
       return null;
    }
 

--- a/exo.kernel.component.cache/src/test/java/org/exoplatform/services/cache/test/TestConcurrentCache.java
+++ b/exo.kernel.component.cache/src/test/java/org/exoplatform/services/cache/test/TestConcurrentCache.java
@@ -215,6 +215,27 @@ public class TestConcurrentCache extends TestCase
       assertEquals(expectedSet, cachedSet);
    }
 
+   public void testHitRatio()
+   {
+      CacheHelper<String, Object> cache = new CacheHelper<String, Object>();
+      cache.setLiveTimeMillis(5);
+      assertEquals(0, cache.getCacheHit());
+      assertEquals(0, cache.getCacheMiss());
+      cache.put("Foo", v1);
+      assertEquals(0, cache.getCacheHit());
+      assertEquals(0, cache.getCacheMiss());
+      assertEquals(v1, cache.get("Foo"));
+      assertEquals(1, cache.getCacheHit());
+      assertEquals(0, cache.getCacheMiss());
+      waitFor(10);
+      assertNull(cache.get("Foo"));
+      assertEquals(1, cache.getCacheHit());
+      assertEquals(1, cache.getCacheMiss());
+      assertNull(cache.get("Foo"));
+      assertEquals(1, cache.getCacheHit());
+      assertEquals(2, cache.getCacheMiss());
+   }
+
    public void testSelect() throws Exception
    {
       CacheHelper<String, Object> cache = new CacheHelper<String, Object>(4);


### PR DESCRIPTION
https://jira.exoplatform.org/browse/KER-293
